### PR TITLE
Upgrade Visual Studio to 17.12.4 / Have the installer silently create…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/chronos"]
+	path = src/chronos
+	url = https://github.com/datadiode/chronos

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Visual Leak Detector (Support Visual Studio 2019 16.7)
+# Visual Leak Detector (Support Visual Studio 2022 17.12)
 
 ## Introduction
 
@@ -18,6 +18,6 @@ We encourage developers who've added their own features, or fixed bugs they've f
 
 * [Source code](https://github.com/oneiric/vld)
 
-Copyright © 2005-2021 VLD Team
+Copyright © 2005-2025 VLD Team
 
  [1]: https://github.com/oneiric/vld/blob/master/COPYING.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,43 +11,43 @@ environment:
   GTEST_REPEAT: 1
 
   matrix:
-  - VldStackWalkMethod: safe
-    Toolset: v90
-    Solution: vld_vs14_wo_mfc.sln
-    GTEST_FILTER: -*.Mfc*
-  - VldStackWalkMethod: safe
-    Toolset: v100
-    Solution: vld_vs14_wo_mfc.sln
-    GTEST_FILTER: -*.Mfc*
-  - VldStackWalkMethod: safe
-    Toolset: v110
-    Solution: vld_vs14_wo_mfc.sln
-    GTEST_FILTER: -*.Mfc*
-  - VldStackWalkMethod: safe
-    Toolset: v120_xp
-    Solution: vld_vs14.sln
+  # - VldStackWalkMethod: safe
+    # Toolset: v90
+    # Solution: vld_vs14_wo_mfc.sln
+    # GTEST_FILTER: -*.Mfc*
+  # - VldStackWalkMethod: safe
+    # Toolset: v100
+    # Solution: vld_vs14_wo_mfc.sln
+    # GTEST_FILTER: -*.Mfc*
+  # - VldStackWalkMethod: safe
+    # Toolset: v110
+    # Solution: vld_vs14_wo_mfc.sln
+    # GTEST_FILTER: -*.Mfc*
+  # - VldStackWalkMethod: safe
+    # Toolset: v120_xp
+    # Solution: vld_vs14.sln
   - VldStackWalkMethod: safe
     Toolset: v140_xp
-    Solution: vld_vs14.sln
+    Solution: vld_vs16.sln
 
-  - VldStackWalkMethod: fast
-    Toolset: v90
-    Solution: vld_vs14_wo_mfc.sln
-    GTEST_FILTER: -*.Mfc*
-  - VldStackWalkMethod: fast
-    Toolset: v100
-    Solution: vld_vs14_wo_mfc.sln
-    GTEST_FILTER: -*.Mfc*
-  - VldStackWalkMethod: fast
-    Toolset: v110
-    Solution: vld_vs14_wo_mfc.sln
-    GTEST_FILTER: -*.Mfc*
-  - VldStackWalkMethod: fast
-    Toolset: v120_xp
-    Solution: vld_vs14.sln
+  # - VldStackWalkMethod: fast
+    # Toolset: v90
+    # Solution: vld_vs14_wo_mfc.sln
+    # GTEST_FILTER: -*.Mfc*
+  # - VldStackWalkMethod: fast
+    # Toolset: v100
+    # Solution: vld_vs14_wo_mfc.sln
+    # GTEST_FILTER: -*.Mfc*
+  # - VldStackWalkMethod: fast
+    # Toolset: v110
+    # Solution: vld_vs14_wo_mfc.sln
+    # GTEST_FILTER: -*.Mfc*
+  # - VldStackWalkMethod: fast
+    # Toolset: v120_xp
+    # Solution: vld_vs14.sln
   - VldStackWalkMethod: fast
     Toolset: v140_xp
-    Solution: vld_vs14.sln
+    Solution: vld_vs16.sln
 
 platform:
   - Win32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,9 +55,9 @@ platform:
 
 configuration:
   - Debug_VldRelease
-  - Debug_VldRelease_StaticCrt
+  # - Debug_VldRelease_StaticCrt
   - Release
-  - Release_StaticCrt
+  # - Release_StaticCrt
 
 matrix:
   fast_finish: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ build_script:
         return
     }
     & .\change_toolset.ps1 $env:Toolset
-    msbuild /v:m /p:"Configuration=$env:CONFIGURATION" /p:Platform="$env:PLATFORM" "$env:Solution" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    msbuild /v:m /p:"Configuration=$env:CONFIGURATION" /p:Platform="$env:PLATFORM" /p:PlatformToolset=$env:Toolset "$env:Solution" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 test_script:
 - ps: |

--- a/lib/cppformat/format.vcxproj
+++ b/lib/cppformat/format.vcxproj
@@ -30,7 +30,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/lib/gtest/msvc/gtest.vcxproj
+++ b/lib/gtest/msvc/gtest.vcxproj
@@ -44,7 +44,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/setup/version.h
+++ b/setup/version.h
@@ -1,5 +1,5 @@
 
-#define VLDVERSION          L"2.8.0"
-#define VERSION_NUMBER      2,8,0,0
-#define VERSION_STRING      "2.8.0.0"
+#define VLDVERSION          L"2.8.1"
+#define VERSION_NUMBER      2,8,1,0
+#define VERSION_STRING      "2.8.1.0"
 #define VERSION_COPYRIGHT   "Copyright (C) 2005-2025"

--- a/setup/version.h
+++ b/setup/version.h
@@ -1,9 +1,5 @@
 
-#define VLDVERSION          L"2.7.0"
-#define VERSION_NUMBER		2,7,0,0
-#define VERSION_STRING		"2.7.0.0"
-#define VERSION_COPYRIGHT	"Copyright (C) 2005-2021"
-
-#ifndef __FILE__
-!define VLD_VERSION "2.7.0"	// NSIS Script
-#endif
+#define VLDVERSION          L"2.8.0"
+#define VERSION_NUMBER      2,8,0,0
+#define VERSION_STRING      "2.8.0.0"
+#define VERSION_COPYRIGHT   "Copyright (C) 2005-2025"

--- a/setup/version.h
+++ b/setup/version.h
@@ -1,5 +1,5 @@
 
-#define VLDVERSION          L"2.8.1"
-#define VERSION_NUMBER      2,8,1,0
-#define VERSION_STRING      "2.8.1.0"
+#define VLDVERSION          L"2.8.2"
+#define VERSION_NUMBER      2,8,2,0
+#define VERSION_STRING      "2.8.2.0"
 #define VERSION_COPYRIGHT   "Copyright (C) 2005-2025"

--- a/setup/vld-setup.iss
+++ b/setup/vld-setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Visual Leak Detector"
-#define MyAppVersion "2.8.1"
+#define MyAppVersion "2.8.2"
 #define MyAppPublisher "VLD Team"
 #define MyAppURL "https://github.com/oneiric/vld"
 #define MyAppRegKey "Software\Visual Leak Detector"

--- a/setup/vld-setup.iss
+++ b/setup/vld-setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Visual Leak Detector"
-#define MyAppVersion "2.8.0"
+#define MyAppVersion "2.8.1"
 #define MyAppPublisher "VLD Team"
 #define MyAppURL "https://github.com/oneiric/vld"
 #define MyAppRegKey "Software\Visual Leak Detector"
@@ -41,6 +41,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "{group}\View Documentation"; Filename: "http://vld.codeplex.com/documentation"
 
 [Files]
+Source: "..\x64\Release\chronos_x64.exe"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
+Source: "..\Release\chronos_x86.exe"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion
+Source: "..\src\chronos\LICENSE"; DestDir: "{app}"; DestName: "LICENSE_chronos.txt"; Flags: ignoreversion
 Source: "dbghelp\x64\dbghelp.dll"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
 Source: "dbghelp\x64\Microsoft.DTfW.DHL.manifest"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
 Source: "dbghelp\x86\dbghelp.dll"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion

--- a/setup/vld-setup.iss
+++ b/setup/vld-setup.iss
@@ -2,9 +2,9 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Visual Leak Detector"
-#define MyAppVersion "2.7.0"
+#define MyAppVersion "2.8.0"
 #define MyAppPublisher "VLD Team"
-#define MyAppURL "http://vld.codeplex.com/"
+#define MyAppURL "https://github.com/oneiric/vld"
 #define MyAppRegKey "Software\Visual Leak Detector"
 
 [Setup]
@@ -25,7 +25,7 @@ LicenseFile=license-free.txt
 OutputBaseFilename=vld-{#MyAppVersion}-setup
 Compression=lzma
 SolidCompression=True
-MinVersion=0,6.0
+MinVersion=0,6.1
 ; Tell Windows Explorer to reload the environment
 ChangesEnvironment=yes
 AllowNoIcons=yes
@@ -45,12 +45,12 @@ Source: "dbghelp\x64\dbghelp.dll"; DestDir: "{app}\bin\Win64"; Flags: ignorevers
 Source: "dbghelp\x64\Microsoft.DTfW.DHL.manifest"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
 Source: "dbghelp\x86\dbghelp.dll"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion
 Source: "dbghelp\x86\Microsoft.DTfW.DHL.manifest"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion
-Source: "..\src\bin\Win32\Release-v142\vld.lib"; DestDir: "{app}\lib\Win32"; Flags: ignoreversion
-Source: "..\src\bin\Win32\Release-v142\vld_x86.dll"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion
-Source: "..\src\bin\Win32\Release-v142\vld_x86.pdb"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion
-Source: "..\src\bin\x64\Release-v142\vld.lib"; DestDir: "{app}\lib\Win64"; Flags: ignoreversion
-Source: "..\src\bin\x64\Release-v142\vld_x64.dll"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
-Source: "..\src\bin\x64\Release-v142\vld_x64.pdb"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
+Source: "..\src\bin\Win32\Release-v143\vld.lib"; DestDir: "{app}\lib\Win32"; Flags: ignoreversion
+Source: "..\src\bin\Win32\Release-v143\vld_x86.dll"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion
+Source: "..\src\bin\Win32\Release-v143\vld_x86.pdb"; DestDir: "{app}\bin\Win32"; Flags: ignoreversion
+Source: "..\src\bin\x64\Release-v143\vld.lib"; DestDir: "{app}\lib\Win64"; Flags: ignoreversion
+Source: "..\src\bin\x64\Release-v143\vld_x64.dll"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
+Source: "..\src\bin\x64\Release-v143\vld_x64.pdb"; DestDir: "{app}\bin\Win64"; Flags: ignoreversion
 Source: "..\src\vld.h"; DestDir: "{app}\include"; Flags: ignoreversion
 Source: "..\src\vld_def.h"; DestDir: "{app}\include"; Flags: ignoreversion
 Source: "..\vld.ini"; DestDir: "{app}"; Flags: ignoreversion
@@ -61,7 +61,7 @@ Source: "..\COPYING.txt"; DestDir: "{app}"; Flags: ignoreversion
 [Tasks]
 Name: "modifypath"; Description: "Add VLD directory to your environmental path"
 Name: "modifyVS2008Props"; Description: "Add VLD directory to VS 2008"
-Name: "modifyVS2010Props"; Description: "Add VLD directory to VS 2010 - VS 2019"
+Name: "modifyVS2010Props"; Description: "Add VLD directory to VS 2010 - VS 2022"
 
 [ThirdParty]
 UseRelativePaths=True
@@ -318,12 +318,28 @@ var
   StaticLibraryDirectoriesNode: Variant;
   AdditionalStaticLibraryDirectories: string;
 begin
-  if not FileExists(filename) then
-    Exit;
   XMLDocument := CreateOleObject('Msxml2.DOMDocument.3.0');
   try
     XMLDocument.async := False;
-    XMLDocument.load(filename);
+    XMLDocument.preserveWhiteSpace := True;
+    if FileExists(filename) then
+      XMLDocument.load(filename)
+    else
+      XMLDocument.loadXML(
+        '<?xml version="1.0" encoding="utf-8"?>'#13#10
+        '<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">'#13#10
+        '  <ItemDefinitionGroup>'#13#10
+        '    <ClCompile>'#13#10
+        '      <AdditionalIncludeDirectories></AdditionalIncludeDirectories>'#13#10
+        '    </ClCompile>'#13#10
+        '    <Link>'#13#10
+        '      <AdditionalLibraryDirectories></AdditionalLibraryDirectories>'#13#10
+        '    </Link>'#13#10
+        '    <Lib>'#13#10
+        '      <AdditionalLibraryDirectories></AdditionalLibraryDirectories>'#13#10
+        '    </Lib>'#13#10
+        '  </ItemDefinitionGroup>'#13#10
+        '</Project>'#13#10);
     if (XMLDocument.parseError.errorCode = 0) then
     begin
       XMLDocument.setProperty('SelectionLanguage', 'XPath');
@@ -426,7 +442,7 @@ var
   Path: string;
 begin
   Path := GetEnv('LOCALAPPDATA')+'\Microsoft\MSBuild\v4.0\';
-  if DirExists(Path) then
+  if ForceDirectories(Path) then
   begin
     ModifyProps(Path + 'Microsoft.Cpp.Win32.user.props', 'Win32');
     ModifyProps(Path + 'Microsoft.Cpp.x64.user.props', 'Win64');

--- a/src/dllspatches.cpp
+++ b/src/dllspatches.cpp
@@ -769,6 +769,16 @@ patchentry_t VisualLeakDetector::m_ntdllPatch [] = {
     NULL,                 NULL, NULL
 };
 
+patchentry_t VisualLeakDetector::m_winsockPatch [] = {
+    "socket",             NULL, _socket,
+    "accept",             NULL, _accept,
+    "connect",            NULL, _connect,
+    "closesocket",        NULL, _closesocket,
+    "WSACreateEvent",     NULL, _WSACreateEvent,
+    "WSACloseEvent",      NULL, _WSACloseEvent,
+    NULL,                 NULL, NULL
+};
+
 patchentry_t VisualLeakDetector::m_ole32Patch [] = {
     "CoGetMalloc",        NULL, _CoGetMalloc,
     "CoTaskMemAlloc",     NULL, _CoTaskMemAlloc,
@@ -841,6 +851,9 @@ moduleentry_t VisualLeakDetector::m_patchTable [] = {
 
     // NT APIs.
     "ntdll.dll",    FALSE,  0x0, m_ntdllPatch,
+
+    // Winsock APIs.
+    "ws2_32.dll",   FALSE,  0x0, m_winsockPatch,
 
     // COM heap APIs.
     "ole32.dll",    FALSE,  0x0, m_ole32Patch

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cerrno>
 #include <cstdio>
+#include <winsock2.h>
 #include <shlwapi.h>
 #if _WIN32_WINNT < 0x0600 // Windows XP or earlier, no GetProcessIdOfThread()
 #include <winternl.h>

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -3,7 +3,7 @@
 #include <cassert>
 #include <cerrno>
 #include <cstdio>
-#include <windows.h>
+#include <shlwapi.h>
 #if _WIN32_WINNT < 0x0600 // Windows XP or earlier, no GetProcessIdOfThread()
 #include <winternl.h>
 #endif

--- a/src/tests/basics/Allocs.cpp
+++ b/src/tests/basics/Allocs.cpp
@@ -31,12 +31,8 @@
 #define CRTDLLNAME   _T("msvcr110d.dll")
 #elif _MSC_VER == 1800	// VS 2013
 #define CRTDLLNAME   _T("msvcr120d.dll")
-#elif _MSC_VER == 1900	// VS 2015
+#elif _MSC_VER >= 1900	// VS 2015+
 #define CRTDLLNAME   _T("ucrtbased.dll")
-#elif _MSC_VER == 1924	// VS 2019 16.4
-#define CRTDLLNAME   _T("ucrtbased.dll")
-#elif _MSC_VER == 1927 	// VS 2019 16.7
-#define CRTDLLNAME   _T("ucrtbase.dll")
 #else
 #error Unsupported compiler
 #endif
@@ -59,11 +55,7 @@
 #define CRTDLLNAME   _T("msvcr110.dll")
 #elif _MSC_VER == 1800	// VS 2013
 #define CRTDLLNAME   _T("msvcr120.dll")
-#elif _MSC_VER == 1900	// VS 2015
-#define CRTDLLNAME   _T("ucrtbase.dll")
-#elif _MSC_VER == 1924	// VS 2019 16.4
-#define CRTDLLNAME   _T("ucrtbase.dll")
-#elif _MSC_VER == 1927 	// VS 2019 16.7
+#elif _MSC_VER >= 1900	// VS 2015+
 #define CRTDLLNAME   _T("ucrtbase.dll")
 #else
 #error Unsupported compiler

--- a/src/tests/basics/basics.vcxproj
+++ b/src/tests/basics/basics.vcxproj
@@ -61,7 +61,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/corruption/corruption.vcxproj
+++ b/src/tests/corruption/corruption.vcxproj
@@ -61,7 +61,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/dynamic_app/dynamic_app.vcxproj
+++ b/src/tests/dynamic_app/dynamic_app.vcxproj
@@ -61,7 +61,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/dynamic_dll/dynamic.vcxproj
+++ b/src/tests/dynamic_dll/dynamic.vcxproj
@@ -61,7 +61,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/mfc/vldmfc.vcxproj
+++ b/src/tests/mfc/vldmfc.vcxproj
@@ -45,7 +45,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseOfMfc>Dynamic</UseOfMfc>

--- a/src/tests/mfc_dll/mfc.vcxproj
+++ b/src/tests/mfc_dll/mfc.vcxproj
@@ -61,7 +61,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/suite/testsuite.cpp
+++ b/src/tests/suite/testsuite.cpp
@@ -69,12 +69,8 @@ enum action_e {
 #define CRTDLLNAME   _T("msvcr110d.dll")
 #elif _MSC_VER == 1800	// VS 2013
 #define CRTDLLNAME   _T("msvcr120d.dll")
-#elif _MSC_VER == 1900	// VS 2015
+#elif _MSC_VER >= 1900	// VS 2015+
 #define CRTDLLNAME   _T("ucrtbased.dll")
-#elif _MSC_VER == 1924	// VS 2019
-#define CRTDLLNAME   _T("ucrtbased.dll")
-#elif _MSC_VER == 1927 	// VS 2019 16.7
-#define CRTDLLNAME   _T("ucrtbase.dll")
 #else
 #error Unsupported compiler
 #endif
@@ -97,11 +93,7 @@ enum action_e {
 #define CRTDLLNAME   _T("msvcr110.dll")
 #elif _MSC_VER == 1800	// VS 2013
 #define CRTDLLNAME   _T("msvcr120.dll")
-#elif _MSC_VER == 1900	// VS 2015
-#define CRTDLLNAME   _T("ucrtbase.dll")
-#elif _MSC_VER == 1924 	// VS 2019 16.4
-#define CRTDLLNAME   _T("ucrtbase.dll")
-#elif _MSC_VER == 1927 	// VS 2019 16.7
+#elif _MSC_VER >= 1900	// VS 2015+
 #define CRTDLLNAME   _T("ucrtbase.dll")
 #else
 #error Unsupported compiler

--- a/src/tests/suite/testsuite.vcxproj
+++ b/src/tests/suite/testsuite.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/tests/vld_ComTest/ComTest_vs14.vcxproj
+++ b/src/tests/vld_ComTest/ComTest_vs14.vcxproj
@@ -61,7 +61,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/vld_dll1/vld_dll1_vs14.vcxproj
+++ b/src/tests/vld_dll1/vld_dll1_vs14.vcxproj
@@ -60,7 +60,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_dll2/vld_dll2_vs14.vcxproj
+++ b/src/tests/vld_dll2/vld_dll2_vs14.vcxproj
@@ -60,7 +60,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_main/vld_main_vs14.vcxproj
+++ b/src/tests/vld_main/vld_main_vs14.vcxproj
@@ -60,7 +60,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_main_test/vld_main_test_vs14.vcxproj
+++ b/src/tests/vld_main_test/vld_main_test_vs14.vcxproj
@@ -60,7 +60,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_unload/vld_unload_vs14.vcxproj
+++ b/src/tests/vld_unload/vld_unload_vs14.vcxproj
@@ -60,7 +60,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -866,19 +866,11 @@ VOID VisualLeakDetector::attachToLoadedModules (ModuleSet *newmodules)
             {
                 // This module does not import VLD. This means that none of the module's
                 // sources #included vld.h.
-                if ((m_options & VLD_OPT_MODULE_LIST_INCLUDE) != 0)
+                const BOOL match = PathMatchSpecW(modulename, m_forcedModuleList);
+                if ((m_options & VLD_OPT_MODULE_LIST_INCLUDE) != (match ? VLD_OPT_MODULE_LIST_INCLUDE : 0))
                 {
-                    if (wcsstr(m_forcedModuleList, modulename) == NULL) {
-                        // Exclude this module from leak detection.
-                        moduleFlags |= VLD_MODULE_EXCLUDED;
-                    }
-                }
-                else
-                {
-                    if (wcsstr(m_forcedModuleList, modulename) != NULL) {
-                        // Exclude this module from leak detection.
-                         moduleFlags |= VLD_MODULE_EXCLUDED;
-                    }
+                    // Exclude this module from leak detection.
+                    moduleFlags |= VLD_MODULE_EXCLUDED;
                 }
             }
         }

--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -1350,6 +1350,7 @@ VOID VisualLeakDetector::mapBlock (HANDLE heap, LPCVOID mem, SIZE_T size, bool d
     blockinfo->reported = false;
     blockinfo->debugCrtAlloc = debugcrtalloc;
     blockinfo->ucrt = ucrt;
+    blockinfo->resource = IS_INTRESOURCE(heap);
 
     if (SIZE_MAX - m_totalAlloc > size)
         m_totalAlloc += size;
@@ -1672,6 +1673,9 @@ VOID VisualLeakDetector::reportConfig ()
 
 bool VisualLeakDetector::isDebugCrtAlloc( LPCVOID block, blockinfo_t* info )
 {
+    if (info->resource)
+        return false;
+
     // Autodetection allocations from statically linked CRT
     if (!info->debugCrtAlloc) {
         crtdbgblockheader_t* crtheader = (crtdbgblockheader_t*)block;
@@ -1908,7 +1912,7 @@ SIZE_T VisualLeakDetector::reportLeaks (heapinfo_t* heapinfo, bool &firstLeak, S
             info->callStack->dump(m_options & VLD_OPT_TRACE_INTERNAL_FRAMES);
 
         // Dump the data in the user data section of the memory block.
-        if (m_maxDataDump != 0) {
+        if (m_maxDataDump != 0 && size != 0) {
             Report(L"  Data:\n");
             if (m_options & VLD_OPT_UNICODE_REPORT) {
                 DumpMemoryW(address, (m_maxDataDump < size) ? m_maxDataDump : size);

--- a/src/vld.vcxproj
+++ b/src/vld.vcxproj
@@ -32,7 +32,7 @@
   <!-- Import Default Property Sheets -->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Global properties -->

--- a/src/vld.vcxproj
+++ b/src/vld.vcxproj
@@ -88,7 +88,7 @@
       <DisableSpecificWarnings>4201;4229;4091;4302;4311;4312;4127</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
     <Manifest>
@@ -107,7 +107,7 @@
       <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
     <Manifest>
@@ -135,6 +135,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>vld.dll.dependency.x86.manifest</AdditionalManifestFiles>
@@ -160,6 +161,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <Profile>true</Profile>
       <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>vld.dll.dependency.x64.manifest</AdditionalManifestFiles>

--- a/src/vld.vcxproj
+++ b/src/vld.vcxproj
@@ -88,7 +88,7 @@
       <DisableSpecificWarnings>4201;4229;4091;4302;4311;4312;4127</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
     <Manifest>
@@ -107,7 +107,7 @@
       <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
     <Manifest>
@@ -135,7 +135,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>vld.dll.dependency.x86.manifest</AdditionalManifestFiles>
@@ -161,7 +161,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <Profile>true</Profile>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>vld.dll.dependency.x64.manifest</AdditionalManifestFiles>

--- a/src/vldint.h
+++ b/src/vldint.h
@@ -111,6 +111,7 @@ struct blockinfo_t {
     bool       reported;
     bool       debugCrtAlloc;
     bool       ucrt;
+    bool       resource;
 };
 
 // BlockMaps map memory blocks (via their addresses) to blockinfo_t structures.
@@ -353,6 +354,14 @@ private:
     static BYTE     __stdcall _RtlFreeHeap (HANDLE heap, DWORD flags, LPVOID mem);
     static LPVOID   __stdcall _RtlReAllocateHeap (HANDLE heap, DWORD flags, LPVOID mem, SIZE_T size);
 
+    // Winsock IAT replacement functions
+    static SOCKET   __stdcall _socket (int af, int type, int protocol);
+    static SOCKET   __stdcall _accept (SOCKET s, struct sockaddr *addr, int *addrlen);
+    static SOCKET   __stdcall _connect (SOCKET s, const struct sockaddr *name, int namelen);
+    static int      __stdcall _closesocket (SOCKET s);
+    static WSAEVENT __stdcall _WSACreateEvent ();
+    static BOOL     __stdcall _WSACloseEvent (WSAEVENT hEvent);
+
     // COM IAT replacement functions
     static HRESULT __stdcall _CoGetMalloc (DWORD context, LPMALLOC *imalloc);
     static LPVOID  __stdcall _CoTaskMemAlloc (SIZE_T size);
@@ -379,8 +388,9 @@ private:
     static patchentry_t  m_kernelbasePatch [];
     static patchentry_t  m_kernel32Patch [];
     static patchentry_t  m_ntdllPatch [];
+    static patchentry_t  m_winsockPatch [];
     static patchentry_t  m_ole32Patch [];
-    static moduleentry_t m_patchTable [58];   // Table of imports patched for attaching VLD to other modules.
+    static moduleentry_t m_patchTable [59];   // Table of imports patched for attaching VLD to other modules.
     FILE                *m_reportFile;        // File where the memory leak report may be sent to.
     WCHAR                m_reportFilePath [MAX_PATH]; // Full path and name of file to send memory leak report to.
     const char          *m_selfTestFile;      // Filename where the memory leak self-test block is leaked.

--- a/vld_vs16.sln
+++ b/vld_vs16.sln
@@ -71,6 +71,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vld_main_test", "src\tests\
 		{8C732490-DC1A-40C0-923F-1555B9141B80} = {8C732490-DC1A-40C0-923F-1555B9141B80}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "chronos", "src\chronos\chronos.vcxproj", "{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug_StaticCrt|Win32 = Debug_StaticCrt|Win32
@@ -472,6 +474,30 @@ Global
 		{BB99EDE9-D039-4169-B26B-6BFD93C6AF8E}.Release|Win32.Build.0 = Release|Win32
 		{BB99EDE9-D039-4169-B26B-6BFD93C6AF8E}.Release|x64.ActiveCfg = Release|x64
 		{BB99EDE9-D039-4169-B26B-6BFD93C6AF8E}.Release|x64.Build.0 = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_StaticCrt|Win32.ActiveCfg = Debug|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_StaticCrt|Win32.Build.0 = Debug|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_StaticCrt|x64.ActiveCfg = Debug|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_StaticCrt|x64.Build.0 = Debug|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease_StaticCrt|Win32.ActiveCfg = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease_StaticCrt|Win32.Build.0 = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease_StaticCrt|x64.ActiveCfg = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease_StaticCrt|x64.Build.0 = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease|Win32.ActiveCfg = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease|Win32.Build.0 = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease|x64.ActiveCfg = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug_VldRelease|x64.Build.0 = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug|Win32.ActiveCfg = Debug|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug|Win32.Build.0 = Debug|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug|x64.ActiveCfg = Debug|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Debug|x64.Build.0 = Debug|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release_StaticCrt|Win32.ActiveCfg = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release_StaticCrt|Win32.Build.0 = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release_StaticCrt|x64.ActiveCfg = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release_StaticCrt|x64.Build.0 = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release|Win32.ActiveCfg = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release|Win32.Build.0 = Release|Win32
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release|x64.ActiveCfg = Release|x64
+		{3DB94AD0-4960-4D71-B10A-F3A56AEA4C5D}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
… any missing Microsoft.Cpp.*.user.props files to reduce hassle with Visual Studio 2019+ which no longer creates them by default / Remove an NSIS leftover

This happens to fix #10.